### PR TITLE
Fix bug with small-step machine

### DIFF
--- a/the_meaning_of_programs/small_step/machine.rb
+++ b/the_meaning_of_programs/small_step/machine.rb
@@ -1,6 +1,7 @@
 class Machine < Struct.new(:statement, :environment)
   def step
-    self.statement, self.environment = statement.reduce(environment)
+    self.statement, new_environment = statement.reduce(environment)
+    self.environment = new_environment unless new_environment.nil?
   end
 
   def run

--- a/the_meaning_of_programs/spec/small_step_spec.rb
+++ b/the_meaning_of_programs/spec/small_step_spec.rb
@@ -2,6 +2,13 @@ require_relative 'spec_helper'
 require_relative '../small_step'
 
 describe 'the small-step operational semantics of Simple' do
+  describe 'a machine' do
+    context 'with an expression that accesses the environment twice' do
+      subject { Machine.new(Add.new(Variable.new(:x), Variable.new(:x)), {x: Number.new(1)}) }
+      it { should run_without_errors }
+    end
+  end
+
   describe 'expressions' do
     describe 'a variable' do
       subject { Variable.new(:x) }

--- a/the_meaning_of_programs/spec/spec_helper.rb
+++ b/the_meaning_of_programs/spec/spec_helper.rb
@@ -135,3 +135,10 @@ RSpec::Matchers.define :parse_as do |expected|
     "expected that #{subject.inspect} would parse as #{expected.inspect}, but it parses as #{actual(subject).inspect}"
   end
 end
+
+RSpec::Matchers.define :run_without_errors do
+  match do |subject|
+    subject.run
+    true
+  end
+end


### PR DESCRIPTION
Small-step machine could not handle environment lookups after evaluating
an expression, since reducing an expression does not return an
environment.
