### PR TITLE
consistent irb prompt as the book's expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Each directory contains definitions of the classes implemented in that chapter. 
 For example:
 
 ```irb
-$ irb -I.
+$ irb -I. --simple-prompt
 >> require 'universality_is_everywhere'
 => true
 >> identity = SKICall.new(SKICall.new(S, K), SKICall.new(K, K))
@@ -57,7 +57,7 @@ x
 If you run `bundle install` to install [Treetop](http://treetop.rubyforge.org/), you can try out the parsers:
 
 ```irb
-$ bundle exec irb -I.
+$ bundle exec irb -I. --simple-prompt
 >> require 'treetop'
 => true
 >> Treetop.load('the_meaning_of_programs/parser/simple')
@@ -77,7 +77,7 @@ $ bundle exec irb -I.
 ```
 
 ```irb
-$ bundle exec irb -I.
+$ bundle exec irb -I. --simple-prompt
 >> require 'treetop'
 => true
 >> Treetop.load('programming_with_nothing/lambda_calculus/lambda_calculus')

--- a/programming_with_nothing/README.md
+++ b/programming_with_nothing/README.md
@@ -4,7 +4,7 @@ Programming with Nothing
 This chapter includes an implementation of FizzBuzz written with just procs:
 
 ```irb
-$ irb -I.
+$ irb -I. --simple-prompt
 >> require 'programming_with_nothing'
 => true
 >> MULTIPLY[THREE][FIVE]
@@ -43,7 +43,7 @@ Watch [this video](http://rubymanor.org/3/videos/programming_with_nothing/) for 
 There’s also an implementation of the call-by-value small-step operational semantics of the lambda calculus, along with a parser for Ruby-style lambda calculus expressions:
 
 ```irb
-$ bundle exec irb -I.
+$ bundle exec irb -I. --simple-prompt
 >> require 'treetop'
 => true
 >> Treetop.load('programming_with_nothing/lambda_calculus/lambda_calculus')

--- a/the_meaning_of_programs/README.md
+++ b/the_meaning_of_programs/README.md
@@ -4,7 +4,7 @@ The Meaning of Programs
 [This chapter](http://computationbook.com/sample) includes Ruby implementations of the semantics of a toy programming language (“Simple”) written in three contrasting styles: [small-step operational](small_step), [big-step operational](big_step) and [denotational](denotational):
 
 ```irb
-$ bundle exec irb -I.
+$ bundle exec irb -I. --simple-prompt
 >> require 'the_meaning_of_programs'
 => true
 >> expression = LessThan.new(Add.new(Variable.new(:x), Number.new(1)), Number.new(5))


### PR DESCRIPTION
Since the book "Understanding Computation" always mentions `>>` prompt for Ruby's interactive console, it should be more precise to take option `--simple-prompt`.
